### PR TITLE
Early stopping

### DIFF
--- a/pypop7/optimizers/core/_test_optimizer.py
+++ b/pypop7/optimizers/core/_test_optimizer.py
@@ -1,0 +1,42 @@
+"""
+Test the common optimizer interface.
+"""
+import unittest
+
+import numpy as np
+
+from pypop7.benchmarks.base_functions import rosenbrock
+from pypop7.optimizers.core.optimizer import Terminations
+from pypop7.optimizers.de.cde import CDE
+from pypop7.optimizers.es.fmaes import FMAES
+
+
+class TestOptimizer(unittest.TestCase):
+    def test_early_stopping(self):
+        ndim_problem = 10
+        early_stopping_threshold = 1e-8
+        early_stopping_evaluations = 10000
+
+        # This function is needed to avoid the fitness_threshold condition
+        rosenbrock_plus_one = lambda x: rosenbrock(x) + 1
+
+        for Solver in [CDE, FMAES]:
+            problem = {'fitness_function': rosenbrock_plus_one,
+                       'ndim_problem': ndim_problem,
+                       'lower_boundary': -5 * np.ones((ndim_problem,)),
+                       'upper_boundary': 5 * np.ones((ndim_problem,))}
+            options = {'max_function_evaluations': 2e6,
+                       'fitness_threshold': 1e-10,
+                       'seed_rng': 0,
+                       'early_stopping_threshold': early_stopping_threshold,
+                       'early_stopping_evaluations': early_stopping_evaluations,
+                       'verbose': 200,
+                       'sigma': 1e-3,
+                       }
+            solver = Solver(problem, options)
+            results = solver.optimize()
+            self.assertTrue(results['termination_signal'], Terminations.EARLY_STOPPING)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pypop7/optimizers/core/optimizer.py
+++ b/pypop7/optimizers/core/optimizer.py
@@ -85,6 +85,7 @@ class Optimizer(object):
         self.early_stopping_evaluations = options.get('early_stopping_evaluations', np.Inf)
         self.early_stopping_threshold = options.get('early_stopping_threshold', 0)
         self.early_stopping_counter = 0
+        self.early_stopping_best_so_far_y = self.best_so_far_y
 
     def _evaluate_fitness(self, x, args=None):
         self.start_function_evaluations = time.time()
@@ -95,14 +96,14 @@ class Optimizer(object):
         self.time_function_evaluations += time.time() - self.start_function_evaluations
         self.n_function_evaluations += 1
         # update best-so-far solution (x) and fitness (y)
-        if y < self.best_so_far_y:
-            if y >= self.best_so_far_y - self.early_stopping_threshold:
-                self.early_stopping_counter += 1
-            else:
-                self.early_stopping_counter = 0
-            self.best_so_far_x, self.best_so_far_y = np.copy(x), y
-        else:
+        if y >= self.early_stopping_best_so_far_y - self.early_stopping_threshold:
             self.early_stopping_counter += 1
+        else:
+            self.early_stopping_counter = 0
+            self.early_stopping_best_so_far_y = y
+
+        if y < self.best_so_far_y:
+            self.best_so_far_x, self.best_so_far_y = np.copy(x), y
 
         return float(y)
 


### PR DESCRIPTION
Added 2 parameters: early_stopping_evaluations and early_stopping_threshold. If no improvements are greater than the early_stopping_threshold for the last early_stopping_evaluations, then the process terminates. 

So, the algorithm should improve best_so_far_y at least by early_stopping_threshold during early_stopping_evaluations function calculations.